### PR TITLE
First tile should never be a mine

### DIFF
--- a/app/src/main/java/cos/premy/mines/MainActivity.java
+++ b/app/src/main/java/cos/premy/mines/MainActivity.java
@@ -8,7 +8,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
-import cos.premy.mines.generator.RandomMinesGenerator;
+import cos.premy.mines.data.MinesContainer;
 import cos.premy.mines.graphics.GameActivity;
 
 public class MainActivity extends AppCompatActivity {
@@ -88,7 +88,8 @@ public class MainActivity extends AppCompatActivity {
                 boolean hardcore = LoadedGame.gameStatus.getHardcore();
                 int numLevels = LoadedGame.gameStatus.getNumLevels();
                 int mines = (int) (baseMines * (hardcore ? 1.5f : 1) * numLevels / 2);
-                LoadedGame.minesContainer = new RandomMinesGenerator().getNewProblem(gridSize, gridSize, numLevels, mines);
+                assert mines < numLevels * gridSize * gridSize;
+                LoadedGame.minesContainer = new MinesContainer(gridSize, gridSize, numLevels, mines);
 
                 startActivity(myIntent);
             }

--- a/app/src/main/java/cos/premy/mines/data/MinesContainer.java
+++ b/app/src/main/java/cos/premy/mines/data/MinesContainer.java
@@ -18,6 +18,7 @@ public class MinesContainer {
     private int minesOkBlocked;
     private int minesOpened;
     private final Mine[][][] mines;
+    private boolean factorized;
 
     public MinesContainer(int N, int M, int numLevels, int minesNumber, int minesBlocked, int minesOkBlocked, int minesOpened){
         this.numLevels = numLevels;
@@ -45,6 +46,7 @@ public class MinesContainer {
             }
         }
         initListeners();
+        factorized = false;
     }
 
     public MinesContainer(int N, int M, int numLevels, int minesNumber){
@@ -167,6 +169,10 @@ public class MinesContainer {
         return width;
     }
 
+    public int getNumLevels(){
+        return numLevels;
+    }
+
     public Mine getMine(int z, int y, int x){
         return mines[z][y][x];
     }
@@ -180,7 +186,11 @@ public class MinesContainer {
                 }
             }
         }
+        factorized = true;
     }
 
+    public boolean getFactorized() {
+        return factorized;
+    }
 
 }

--- a/app/src/main/java/cos/premy/mines/data/MinesContainer.java
+++ b/app/src/main/java/cos/premy/mines/data/MinesContainer.java
@@ -28,12 +28,9 @@ public class MinesContainer {
         this.minesOkBlocked = minesOkBlocked;
         this.minesOpened = minesOpened;
 
-        mines = new Mine[numLevels][][];
+        mines = new Mine[numLevels][N][M];
         for(int i = 0; i != numLevels; i++){
-            mines[i] = new Mine[N][];
-
             for(int ii = 0; ii != N; ii++){
-                mines[i][ii] = new Mine[M];
                 for(int iii = 0; iii != M; iii++){
                     mines[i][ii][iii] = new Mine();
                     //DEBUG

--- a/app/src/main/java/cos/premy/mines/generator/MinesGenerator.java
+++ b/app/src/main/java/cos/premy/mines/generator/MinesGenerator.java
@@ -7,5 +7,13 @@ import cos.premy.mines.data.MinesContainer;
  */
 
 public interface MinesGenerator {
-    public MinesContainer getNewProblem(int N, int M, int numLevels, int minesNumber);
+    /**
+     * Given a container with no real mines, place real mines
+     * on it. It avoids placing a mine on user's first tap
+     * @param container MinesContainer
+     * @param level User's first tap level
+     * @param y User's first tap y tile
+     * @param x User's first tap x tile
+     */
+    public void populateNewProblem(MinesContainer container, int level, int y, int x);
 }

--- a/app/src/main/java/cos/premy/mines/generator/RandomMinesGenerator.java
+++ b/app/src/main/java/cos/premy/mines/generator/RandomMinesGenerator.java
@@ -11,27 +11,26 @@ import cos.premy.mines.data.MinesContainer;
 
 public class RandomMinesGenerator implements MinesGenerator {
     @Override
-    public MinesContainer getNewProblem(int N, int M, int numLevels, int minesNumber){
+    public void populateNewProblem(MinesContainer container, int level, int n, int m) {
         try {
-            MinesContainer ret = new MinesContainer(N, M, numLevels, minesNumber);
+            MinesContainer con = container;
             Random rand = new Random();
             int minesAdded = 0;
-            while (minesAdded != minesNumber) {
-                int z = rand.nextInt(numLevels);
-                int y = rand.nextInt(N);
-                int x = rand.nextInt(M);
-                if (!ret.isRealMine(z, y, x)) {
+            while (minesAdded < con.getMinesNumber()) {
+                int z = rand.nextInt(con.getNumLevels());
+                int y = rand.nextInt(con.getHeight());
+                int x = rand.nextInt(con.getWidth());
+                if (!con.isRealMine(z, y, x)
+                        && !(level == z && n == y && m == x)) {
                     minesAdded++;
-                    ret.getMine(z, y, x).setIsReal(true);
+                    con.getMine(z, y, x).setIsReal(true);
                 }
             }
-            ret.setFactorized();
-            return ret;
+            container.setFactorized();
         }
         catch (MyHappyException ex){
             ex.printStackTrace();
             System.exit(1);
-            return null;
         }
     }
 }

--- a/app/src/main/java/cos/premy/mines/graphics/Grid.java
+++ b/app/src/main/java/cos/premy/mines/graphics/Grid.java
@@ -6,9 +6,9 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 
 import cos.premy.mines.GameStatus;
-import cos.premy.mines.LevelSwitchListener;
 import cos.premy.mines.data.MinesContainer;
 import cos.premy.mines.data.MineCoord;
+import cos.premy.mines.generator.RandomMinesGenerator;
 
 /**
  * Created by premy on 07.11.2017.
@@ -121,6 +121,11 @@ public class Grid extends AbstractDrawable {
 
     @Override
     public void sendVerifiedDoubleTap(int x, int y) {
+        if(!container.getFactorized()) {
+            int mineX = Math.min(M, (x - this.x) * M / width);
+            int mineY = Math.min(N, (y - this.y) * N / height);
+            new RandomMinesGenerator().populateNewProblem(container, gameStatus.getLevel(), mineY, mineX);
+        }
         int level = gameStatus.getLevel();
         for (int i = 0; i != N; i++) {
             for (int ii = 0; ii != M; ii++) {

--- a/app/src/main/java/cos/premy/mines/graphics/Grid.java
+++ b/app/src/main/java/cos/premy/mines/graphics/Grid.java
@@ -29,7 +29,7 @@ public class Grid extends AbstractDrawable {
 
         N = container.getHeight();
         M = container.getWidth();
-        mineFields = new MineField[gameStatus.getNumLevels()][][];
+        mineFields = new MineField[gameStatus.getNumLevels()][N][M];
 
         gameStatus.addLevelSwitchListener(status -> {
             for(int i = 0; i != mineFields.length; i++){;
@@ -48,9 +48,7 @@ public class Grid extends AbstractDrawable {
         paintLine.setStrokeWidth(4F);
 
         for(int i = 0; i != mineFields.length; i++){
-            mineFields[i] = new MineField[N][];
             for(int ii = 0; ii != N; ii++){
-                mineFields[i][ii] = new MineField[M];
                 for(int iii = 0; iii != M; iii++){
                     mineFields[i][ii][iii] = new MineField(this, container.getMine(i, ii, iii), gameStatus, i);
                     mineFields[i][ii][iii].setPosition(x + (ii * height) / N, height / N, y + (iii * width) / M, width / M);

--- a/app/src/main/java/cos/premy/mines/graphics/Grid.java
+++ b/app/src/main/java/cos/premy/mines/graphics/Grid.java
@@ -51,7 +51,7 @@ public class Grid extends AbstractDrawable {
             for(int ii = 0; ii != N; ii++){
                 for(int iii = 0; iii != M; iii++){
                     mineFields[i][ii][iii] = new MineField(this, container.getMine(i, ii, iii), gameStatus, i);
-                    mineFields[i][ii][iii].setPosition(x + (ii * height) / N, height / N, y + (iii * width) / M, width / M);
+                    mineFields[i][ii][iii].setPosition(x + (iii * width) / M, width / M, y + (ii * height) / N, height / N);
                 }
             }
         }
@@ -92,7 +92,7 @@ public class Grid extends AbstractDrawable {
         for(int i = 0; i != mineFields.length; i++){
             for(int ii = 0; ii != N; ii++){
                 for(int iii = 0; iii != M; iii++){
-                    mineFields[i][ii][iii].setPosition(x + (ii * height) / N, height / N, y + (iii * width) / M, width / M);
+                    mineFields[i][ii][iii].setPosition(x + (iii * width) / M, width / M, y + (ii * height) / N, height / N);
                 }
             }
         }


### PR DESCRIPTION
Addresses #5 .

Strategy: don't decide where real mines are until user taps the first tile.
Design choices: Now, MineGenerators are not to return a fully constructed MineContainer. Instead, its implementations act on an existing one, which should contain no real mines yet. Thus, the MainActivity creates the MineContainer on its own and lets the Grid be responsible for triggering the random generation at user's first tile tap.

The branch contains an unrelated fix for the position of mine views.

This can run independent from #31 .